### PR TITLE
DM-27088: Calculate GAaP flux uncertainties

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -34,6 +34,7 @@ from lsst.meas.base.fluxUtilities import FluxResultKey
 import lsst.pex.config as pexConfig
 from lsst.ip.diffim import ModelPsfMatchTask
 from lsst.pex.exceptions import RuntimeError as pexRuntimeError
+import scipy.signal
 
 PLUGIN_NAME = "ext_gaap_GaapFlux"
 
@@ -243,6 +244,26 @@ class BaseGaapFluxPlugin(measBase.GenericPlugin):
     def getExecutionOrder(cls) -> float:
         # Docstring inherited.
         return cls.FLUX_ORDER
+
+    @staticmethod
+    def _computeKernelAcf(kernel: lsst.afw.math.Kernel) -> lsst.afw.image.Image:  # noqa: F821
+        """Compute the auto-correlation function of ``kernel``.
+
+        Parameters
+        ----------
+        kernel : `~lsst.afw.math.Kernel`
+            The kernel for which auto-correlation function is to be computed.
+
+        Returns
+        -------
+        acfImage : `~lsst.afw.image.Image`
+            The two-dimensional auto-correlation function of ``kernel``.
+        """
+        kernelImage = afwImage.ImageD(kernel.getDimensions())
+        kernel.computeImage(kernelImage, False)
+        acfArray = scipy.signal.correlate2d(kernelImage.array, kernelImage.array, boundary='fill')
+        acfImage = afwImage.ImageD(acfArray)
+        return acfImage
 
     def _convolve(self, exposure: afwImage.Exposure, modelPsf: afwDetection.GaussianPsf,
                   measRecord: lsst.afw.table.SourceRecord) -> tuple[lsst.pipe.base.Struct,  # noqa: F821

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -346,7 +346,7 @@ class GaapFluxTestCase(lsst.utils.tests.TestCase):
             modelPsf = afwDetection.GaussianPsf(algorithm.config.modelPsfDimension,
                                                 algorithm.config.modelPsfDimension,
                                                 targetSigma)
-            result, _ = algorithm._generic._convolve(exposure, modelPsf, record)
+            result = algorithm._generic._convolve(exposure, modelPsf, record)
             kernel = result.psfMatchingKernel
             kernelAcf = algorithm._generic._computeKernelAcf(kernel)
             for sigma in gaapConfig.sigmas:

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -412,9 +412,8 @@ class GaapFluxTestCase(lsst.utils.tests.TestCase):
             # We compare the mean of the noisy measurements to its
             # corresponding noiseless measurement instead of the true value
             instFlux = recordNoiseless[instFluxKey]
-            # TODO: DM-27088 will set a saner bar for uncertainty estimates
-            self.assertFloatsAlmostEqual(instFluxErrMean, instFluxStdDev, rtol=0.7)
-            self.assertLess(abs(instFluxMean - instFlux), 3.0*instFluxErrMean/nSamples**0.5)
+            self.assertFloatsAlmostEqual(instFluxErrMean, instFluxStdDev, rtol=0.02)
+            self.assertLess(abs(instFluxMean - instFlux), 2.0*instFluxErrMean/nSamples**0.5)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
This PR covers the changes made to obtain the scalefactor by which the standard errors have to be multiplied to account for correlated noise in the measurement. The theory follows Equations A11 - A17 of Kuijken et al. (2015) paper.