### PR TITLE
DM-29290: GAaP flux measurement with optimal elliptical Gaussian aperture

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -119,7 +119,7 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
 
     doOptimalPhotometry = pexConfig.Field(
         dtype=bool,
-        default=False,  # Temporarily disabled until measurement is implemented.
+        default=True,
         doc="Perform optimal photometry with near maximal SNR using an adaptive elliptical aperture? "
             "This requires a shape algorithm to have been run previously."
     )

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -384,6 +384,22 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         for record in catalog:
             record.set(psfShapeKey, self.dataset.psfShape)
 
+    @staticmethod
+    def invertQuadrupole(shape: afwGeom.Quadrupole) -> afwGeom.Quadrupole:
+        """Compute the Quadrupole object corresponding to the inverse matrix.
+
+        If M = [[Q.getIxx(), Q.getIxy()],
+                [Q.getIxy(), Q.getIyy()]]
+
+        for the input quadrupole Q, the returned quadrupole R corresponds to
+
+        M^{-1} = [[R.getIxx(), R.getIxy()],
+                  [R.getIxy(), R.getIyy()]].
+        """
+        invShape = afwGeom.Quadrupole(shape.getIyy(), shape.getIxx(), -shape.getIxy())
+        invShape.scale(1./shape.getDeterminantRadius()**2)
+        return invShape
+
     def getFluxErrScaling(self, kernel, aperShape):
         """Returns the value by which the standard error has to be scaled due
         to noise correlations.

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -346,6 +346,23 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         self.assertTrue(record[algName + "_flag_edge"])
         self.assertFalse(record[algName + "_flag"])
 
+    def recordPsfShape(self, catalog) -> None:
+        """Record PSF shapes under the appropriate fields in ``catalog``.
+
+        This method must be called after the dataset is realized and a catalog
+        is returned by the `realize` method. It assumes that the schema is
+        non-minimal and has "psfShape_xx", "psfShape_yy" and "psfShape_xy"
+        fields setup
+
+        Parameters
+        ----------
+        catalog : `~lsst.afw.table.SourceCatalog`
+            A source catalog containing records of the simulated sources.
+        """
+        psfShapeKey = afwTable.QuadrupoleKey(catalog.schema["slot_PsfShape"])
+        for record in catalog:
+            record.set(psfShapeKey, self.dataset.psfShape)
+
     def getFluxErrScaling(self, kernel, aperShape):
         """Returns the value by which the standard error has to be scaled due
         to noise correlations.

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -124,6 +124,9 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         gaapPlugin = lsst.meas.extensions.gaap.SingleFrameGaapFluxPlugin(gaapConfig,
                                                                          'ext_gaap_GaapFlux',
                                                                          schema, None)
+        if gaapConfig.doOptimalPhotometry:
+            afwTable.QuadrupoleKey.addFields(schema, "psfShape", "PSF shape")
+            schema.getAliasMap().set("slot_PsfShape", "psfShape")
         return gaapPlugin, schema
 
     def check(self, psfSigma=0.5, flux=1000., scalingFactors=[1.15], forced=False):

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -151,6 +151,8 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         algConfig.scalingFactors = scalingFactors
         algConfig.scaleByFwhm = True
         algConfig.doPsfPhotometry = True
+        # Do not turn on optimal photometry; not robust for a point-source.
+        algConfig.doOptimalPhotometry = False
 
         if forced:
             offset = geom.Extent2D(-12.3, 45.6)

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -247,6 +247,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         gaapConfig.scalingFactors = scalingFactors
         gaapConfig.sigmas = sigmas
         gaapConfig.doPsfPhotometry = True
+        gaapConfig.doOptimalPhotometry = True
 
         gaapConfig.scaleByFwhm = True
         self.assertTrue(gaapConfig.scaleByFwhm)  # Test the getter method.
@@ -255,7 +256,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         sfmTask = self.makeSingleFrameMeasurementTask(algName, dependencies=dependencies, config=config,
                                                       algMetadata=algMetadata)
         exposure, catalog = self.dataset.realize(0.0, sfmTask.schema)
-        # self.recordPsfShape(catalog)  # Uncomment after DM-29290 is merged.
+        self.recordPsfShape(catalog)
         sfmTask.run(catalog, exposure)
 
         for record in catalog:
@@ -263,7 +264,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
             for scalingFactor in scalingFactors:
                 flagName = gaapConfig._getGaapResultName(scalingFactor, "flag_gaussianization", algName)
                 self.assertTrue(record[flagName])
-                for sigma in sigmas:  # ["Optimal"]  # Uncomment after DM-29290 is merged.
+                for sigma in sigmas + ["Optimal"]:
                     baseName = gaapConfig._getGaapResultName(scalingFactor, sigma, algName)
                     self.assertTrue(record[baseName + "_flag"])
                     self.assertFalse(record[baseName + "_flag_bigPsf"])

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -279,7 +279,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         with self.assertRaises(lsst.meas.base.FatalAlgorithmError):
             sfmTask.run(catalog, exposure)
 
-    def testFlags(self, sigmas=[2.5, 3.0, 4.0], scalingFactors=[1.15, 1.25, 1.4]):
+    def testFlags(self, sigmas=[2.5, 3.0, 4.0], scalingFactors=[1.15, 1.25, 1.4, 100.]):
         """Test that GAaP flags are set properly.
 
         Specifically, we test that


### PR DESCRIPTION
This PR implements photometring a source with an elliptical Gaussian aperture, based on a heuristic approach that improves the signal-to-noise ratio of the measurement. This optimal photometry is not robust for unresolved sources, as the aperture may be too small for even reasonable values of `scalingFactor` if the PSF in the reference catalog is small. However, this works well for galaxies and leads to improvement in SNR for elliptical galaxies.