### PR TITLE
DM-30299: Specify `sigmas` in units of arcsec instead of pixels

### DIFF
--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -81,8 +81,8 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
 
     sigmas = pexConfig.ListField(
         dtype=float,
-        default=[4.0, 5.0],
-        doc="List of sigmas (in pixels) of circular Gaussian apertures to apply on "
+        default=[0.7, 1.0],
+        doc="List of sigmas (in arcseconds) of circular Gaussian apertures to apply on "
             "pre-seeing galaxy images. These should be somewhat larger than the PSF "
             "(determined by ``scalingFactors``) to avoid measurement failures."
     )
@@ -175,8 +175,8 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
         """Return the base name for GAaP fields
 
         For example, for a scaling factor of 1.15 for seeing and sigma of the
-        effective Gaussian aperture of 4.0 pixels, the returned value would be
-        "ext_gaap_GaapFlux_1_15x_4_0".
+        effective Gaussian aperture of 0.7 arcsec, the returned value would be
+        "ext_gaap_GaapFlux_1_15x_0_7".
 
         Notes
         -----
@@ -197,7 +197,7 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
         name : `str`, optional
             The exact registered name of the GAaP plugin, typically either
             "ext_gaap_GaapFlux" or "undeblended_ext_gaap_GaapFlux". If ``name``
-            is None, then only the middle part (1_15x_4_0 in the example)
+            is None, then only the middle part (1_15x_0_7 in the example)
             without the leading underscore is returned.
 
         Returns
@@ -214,8 +214,8 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
         """Generate the base names for all of the GAaP fields.
 
         For example, if the plugin is configured with `scalingFactors` = [1.15]
-        and `sigmas` = [4.0, 5.0] the returned expression would yield
-        ("ext_gaap_GaapFlux_1_15x_4_0", "ext_gaap_GaapFlux_1_15x_5_0") when
+        and `sigmas` = [0.7, 1.0] the returned expression would yield
+        ("ext_gaap_GaapFlux_1_15x_0_7", "ext_gaap_GaapFlux_1_15x_1_0") when
         called with ``name`` = "ext_gaap_GaapFlux". It will also generate
         "ext_gaap_GaapFlux_1_15x_PsfFlux" if `doPsfPhotometry` is True.
 
@@ -224,7 +224,7 @@ class BaseGaapFluxConfig(measBase.BaseMeasurementPluginConfig):
         name : `str`, optional
             The exact registered name of the GAaP plugin, typically either
             "ext_gaap_GaapFlux" or "undeblended_ext_gaap_GaapFlux". If ``name``
-            is None, then only the middle parts (("1_15x_4_0", "1_15x_5_0"),
+            is None, then only the middle parts (("1_15x_0_7", "1_15x_1_0"),
             for example) without the leading underscores are returned.
 
         Returns
@@ -648,7 +648,7 @@ class BaseGaapFluxMixin:
         scalingFactor : `float`
             The multiplicative factor by which the seeing is scaled.
         targetSigma : `float`
-            Sigma of the target circular Gaussian PSF.
+            Sigma (in pixels) of the target circular Gaussian PSF.
 
         Returns
         -------

--- a/python/lsst/meas/extensions/gaap/_gaap.py
+++ b/python/lsst/meas/extensions/gaap/_gaap.py
@@ -576,14 +576,14 @@ class BaseGaapFluxMixin:
 
             if self.config.doPsfPhotometry:
                 baseName = self.ConfigClass._getGaapResultName(scalingFactor, "PsfFlux", self.name)
-                aperShape = targetPsf.computeShape()
+                aperShape = psfShape
                 measureFlux(aperShape, baseName, fluxScaling=1)
 
             if self.config.doOptimalPhotometry:
                 baseName = self.ConfigClass._getGaapResultName(scalingFactor, "Optimal", self.name)
                 optimalShape = measRecord.get(self.optimalShapeKey)
                 aperShape = afwGeom.Quadrupole(optimalShape.getParameterVector()
-                                               - targetPsf.computeShape().getParameterVector())
+                                               - psfShape.getParameterVector())
                 measureFlux(aperShape, baseName)
 
             # Iterate over pre-defined circular apertures

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -279,7 +279,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         with self.assertRaises(lsst.meas.base.FatalAlgorithmError):
             sfmTask.run(catalog, exposure)
 
-    def testFlags(self, sigmas=[2.5, 3.0, 4.0], scalingFactors=[1.15, 1.25, 1.4, 100.]):
+    def testFlags(self, sigmas=[0.4, 0.5, 0.7], scalingFactors=[1.15, 1.25, 1.4, 100.]):
         """Test that GAaP flags are set properly.
 
         Specifically, we test that
@@ -292,7 +292,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         Parameters
         ----------
         sigmas : `list` [`float`], optional
-            The list of sigmas (in pixels) to construct the
+            The list of sigmas (in arcseconds) to construct the
             `SingleFrameGaapFluxConfig`.
         scalingFactors : `list` [`float`], optional
             The list of scaling factors to construct the
@@ -515,7 +515,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         fluxErrScaling /= np.sqrt(np.pi*aperSigma**2)
         return fluxErrScaling
 
-    def testCorrelatedNoiseError(self, sigmas=[3.0, 4.0], scalingFactors=[1.15, 1.2, 1.25, 1.3, 1.4]):
+    def testCorrelatedNoiseError(self, sigmas=[0.6, 0.8], scalingFactors=[1.15, 1.2, 1.25, 1.3, 1.4]):
         """Test the scaling to standard error due to correlated noise.
 
         The uncertainty estimate on GAaP fluxes is scaled by an amount
@@ -576,7 +576,8 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
             self.assertFloatsAlmostEqual(fluxErrScaling1, fluxErrScaling2, rtol=1e-4)
 
     @lsst.utils.tests.methodParameters(noise=(0.001, 0.01, 0.1))
-    def testMonteCarlo(self, noise, recordId=1, sigmas=[3.0, 4.0], scalingFactors=[1.1, 1.15, 1.2, 1.3, 1.4]):
+    def testMonteCarlo(self, noise, recordId=1, sigmas=[0.7, 1.0, 1.25],
+                       scalingFactors=[1.1, 1.15, 1.2, 1.3, 1.4]):
         """Test GAaP flux uncertainties.
 
         This test should demonstate that the estimated flux uncertainties agree

--- a/tests/test_gaap.py
+++ b/tests/test_gaap.py
@@ -443,7 +443,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
         intrinsicShape = afwGeom.Quadrupole(intrinsicShapeVector)
         invIntrinsicShape = self.invertQuadrupole(intrinsicShape)
         # Assert that the measured fluxes agree with analytical expectations.
-        for sigma in sfmTask.config.plugins[algName].sigmas.list() + ["Optimal"]:
+        for sigma in sfmTask.config.plugins[algName]._sigmas:
             if sigma == "Optimal":
                 aperShape = afwTable.QuadrupoleKey(schema[f"{algName}_OptimalShape"]).get(refRecord)
             else:
@@ -475,7 +475,7 @@ class GaapFluxTestCase(lsst.meas.base.tests.AlgorithmTestCase, lsst.utils.tests.
 
         # Since measCatalog and refCatalog differ only by WCS, the GAaP flux
         # measured through consistent apertures must agree with each other.
-        for sigma in forcedTask.config.plugins[algName].sigmas.list() + ["Optimal"]:
+        for sigma in forcedTask.config.plugins[algName]._sigmas:
             if sigma == "Optimal":
                 aperShape = afwTable.QuadrupoleKey(measRecord.schema[f"{algName}_"
                                                                      "OptimalShape"]).get(measRecord)


### PR DESCRIPTION
Since the standard mode of operation of the GAaP plugin is in forced mode, the aperture sizes need to be specified in units of arcsec (or sky units in general) as opposed to pixel units. Specifying aperture sizes in pixels will lead to inconsistent apertures in different bands, with different WCS. This PR redefines ``sigmas`` in units of arcsec and reflects these changes in the unit tests as well.